### PR TITLE
Bug/fi 7688 liquid some fields disappeared from query string

### DIFF
--- a/snippets/findify-filter-price-range.liquid
+++ b/snippets/findify-filter-price-range.liquid
@@ -48,8 +48,8 @@
     const submitBtnElement = document.getElementById(submit_btn_selector_id);
 
     const onSubmitHandler = () => {
-      let from = (fromInputElement.value / Shopify.currency.rate).toFixed(2);
-      let to = (toInputElement.value / Shopify.currency.rate).toFixed(2);
+      let from = (fromInputElement.value / window.findifyBGOperationsBlockSettings?.rate).toFixed(2);
+      let to = (toInputElement.value / window.findifyBGOperationsBlockSettings?.rate).toFixed(2);
 
       let value;
       if (from && to) {

--- a/snippets/findify-filter-price-range.liquid
+++ b/snippets/findify-filter-price-range.liquid
@@ -8,23 +8,25 @@
 
 <div class="price-range-container">
   <div class="price-range-content">
-    <div class='findify-price-range-input-container'>
+    <div class="findify-price-range-input-container">
       <input
         min="{{ min_value }}"
         max="{{ max_value }}"
         type="number"
         class="price-range-input"
-        id='{{ input_from_selector_id }}' />
+        id="{{ input_from_selector_id }}"
+      >
       <span>{{ currency }}</span>
     </div>
     <span>-</span>
-    <div class='findify-price-range-input-container'>
+    <div class="findify-price-range-input-container">
       <input
         min="{{ min_value }}"
         max="{{ max_value }}"
         type="number"
         class="price-range-input"
-        id='{{ input_to_selector_id }}' />
+        id="{{ input_to_selector_id }}"
+      >
       <span>{{ currency }}</span>
     </div>
   </div>
@@ -33,21 +35,21 @@
 
 <script>
   const rangeSearch = () => {
-    const filter_name = "{{ name }}"
-    const min_value = "{{ min_value }}";
-    const max_value = "{{ max_value }}"
+    const filter_name = '{{ name }}';
+    const min_value = '{{ min_value }}';
+    const max_value = '{{ max_value }}';
 
-    const input_from_selector_id = "{{ input_from_selector_id }}";
-    const input_to_selector_id = "{{ input_to_selector_id }}";
-    const submit_btn_selector_id = "{{ submit_btn_selector_id }}";
+    const input_from_selector_id = '{{ input_from_selector_id }}';
+    const input_to_selector_id = '{{ input_to_selector_id }}';
+    const submit_btn_selector_id = '{{ submit_btn_selector_id }}';
 
     const fromInputElement = document.getElementById(input_from_selector_id);
     const toInputElement = document.getElementById(input_to_selector_id);
     const submitBtnElement = document.getElementById(submit_btn_selector_id);
 
     const onSubmitHandler = () => {
-      let from = fromInputElement.value;
-      let to = toInputElement.value;
+      let from = (fromInputElement.value / Shopify.currency.rate).toFixed(2);
+      let to = (toInputElement.value / Shopify.currency.rate).toFixed(2);
 
       let value;
       if (from && to) {
@@ -58,13 +60,13 @@
         value = `to|${to}`;
       }
 
-      if(value) {
-        findify.filters.update({ value, type: "range", name: filter_name });
+      if (value) {
+        findify.filters.update({ value, type: 'range', name: filter_name });
       }
-    }
+    };
 
-    submitBtnElement.addEventListener('click', onSubmitHandler)
-  }
+    submitBtnElement.addEventListener('click', onSubmitHandler);
+  };
 
-  rangeSearch()
+  rangeSearch();
 </script>

--- a/snippets/findify-filter-range.liquid
+++ b/snippets/findify-filter-range.liquid
@@ -16,32 +16,42 @@
         assign money_price = fake_price | times: 100 | money
         assign currency = money_price | replace: fake_price, '' | replace: ',00', ''
 
-        if value contains "to"
+        if value contains 'to'
           assign to = value | split: 'to' | last
           assign under_text = 'findify.filters.under' | t
-          assign text = under_text | append: ' ' | append: to | append: currency
+          if name == 'price'
+            assign to = to | times: 100 | money
+          endif
+          assign text = under_text | append: ' ' | append: to
           assign value = 'to|' | append: to
-        elsif value contains "from"
+        elsif value contains 'from'
           assign from = value | split: 'from' | last
           assign and_up_text = 'findify.filters.and_up' | t
-          assign text = from | append: currency | append: ' ' | append: and_up_text
+          if name == 'price'
+            assign from = from | times: 100 | money
+          endif
+          assign text = from | append: ' ' | append: and_up_text
           assign value = 'from|' | append: from
         else
           assign from = value | split: ':' | first
           assign to = value | split: ':' | last
-          assign text = from | append: currency | append: ' - ' | append: to | append: currency
+          if name == 'price'
+            assign to = to | times: 100 | money
+            assign from = from | times: 100 | money
+          endif
+          assign text = from | append: ' - ' | append: to
           assign value = 'from|' | append: from | append: '-' | append: 'to|' | append: to
         endif
       %}
 
-      {% render 'findify-filter-checkbox'
-        , name: name
-        , type: type
-        , is_selected: is_selected
-        , value: value
-        , text: text
-        , count: count
-        , component: component
+      {% render 'findify-filter-checkbox',
+        name: name,
+        type: type,
+        is_selected: is_selected,
+        value: value,
+        text: text,
+        count: count,
+        component: component
       %}
     {% endif %}
 
@@ -50,12 +60,12 @@
         assign min = filter | split: ':' | first
         assign max = filter | split: ':' | last
       %}
-      {% render 'findify-filter-price-range'
-        , name: name
-        , currency: currency
-        , min: min
-        , max: max %}
+      {% render 'findify-filter-price-range',
+        name: name,
+        currency: currency,
+        min: min,
+        max: max
+      %}
     {% endif %}
-
   {% endfor %}
 </div>

--- a/snippets/findify-filter-rating-value.liquid
+++ b/snippets/findify-filter-rating-value.liquid
@@ -1,5 +1,5 @@
 <span class="findify-filters-checkbox-item-value {%if selected == 't'%}findify-filters-checkbox-item-value-selected{% endif %}">
-  {%- assign value = value | split: '-' | first -%}
-  {%- render 'findify-rating'
-    , value: value -%}
+  {%- assign fromValue = value | split: '-' | first -%}
+  {% assign value = fromValue | split: '|' | last %}
+  {%- render 'findify-rating', value: value -%}
 </span>


### PR DESCRIPTION
1.  Fixed a bug with reviews with displaying only one star in all Rating options.
2. Updated `Shopify.currency.rate` to `window.findifyBGOperationsBlockSettings?.rate` (check https://github.com/findify/findify-liquid/pull/124 for details)
3. Refactored Price filter formatting