### PR TITLE
fixed image bug

### DIFF
--- a/sections/findify-content.liquid
+++ b/sections/findify-content.liquid
@@ -35,7 +35,7 @@
 >
     <div class="adapt-content-img content-fallback-img">
       {% if image_url %} 
-        <img src="{{ image_url }}" alt="{{ title }}"/>
+        <img src="{{ image_url |  url_decode }}" alt="{{ title }}"/>
       {% else if %}
         {% render 'findify-content-image-fallback' %}
       {% endif %}

--- a/snippets/findify-autocomplete-view-all.liquid
+++ b/snippets/findify-autocomplete-view-all.liquid
@@ -1,7 +1,7 @@
 {% assign view_all_element_id = 'view-all-element' | append: '-' | append: position %}
 
 <div id="{{ view_all_element_id }}" class="findify-view-all view-all-{{position}}">
-  {%- if query == 'none' -%}
+  {%- if query == '' -%}
     <label>{{ 'findify.autocomplete.view_all' | t }}</label>
   {%- else -%}
     <label>


### PR DESCRIPTION
### Fixes
`snippets/findify-autocomplete-view-all.liquid`
In the current version of Liquid we use empty string instead of none for query. Fixed.
`sections/findify-content.liquid`
fix related to the PR https://github.com/findify/findify-liquid/compare/develop...bug/content-image-url?expand=1

[Preview with the fix](https://yana-test-store.myshopify.com/?_ab=0&_bt=eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaUo1WVc1aExYUmxjM1F0YzNSdmNtVXViWGx6YUc5d2FXWjVMbU52YlFZNkJrVlUiLCJleHAiOiIyMDI0LTA2LTE4VDEwOjU4OjAzLjIwMloiLCJwdXIiOiJwZXJtYW5lbnRfcGFzc3dvcmRfYnlwYXNzIn19--d608abe05c8ec9fe76cdefe82c90db65e6f46b95&_fd=0&_sc=1&key=2e7772c8d721f5344e040930235bdbe1cf4e75e32e1e43e5a3b1ad38902a1b53&preview_theme_id=136027537567)