### PR TITLE
Color Swatches fix

### DIFF
--- a/assets/findify-product-card.js
+++ b/assets/findify-product-card.js
@@ -42,14 +42,14 @@ const setProductUrl = (productCard, url) => {
   );
 }
 
-const onSwatchClick = (event, product_id, product_url, variant_url, variant_image) => {
-
-  const targetedSwatch = event.target;
+const onSwatchClick = (event, product_url, variant_url, variant_image) => {
   
-  const productCard = document.getElementById(product_id);
+  const targetedSwatch = event.target;
+  const productCard = targetedSwatch.closest('div[id].findify-product-card');
   const swatchImage = productCard.querySelector(`.findify-product-swatch-image`);
-
+  
   if(targetedSwatch.classList.contains('active')) {
+
     cleanActiveSwatches(productCard);
     setProductUrl(productCard, product_url);
     swatchImage.setAttribute('hidden', true);

--- a/assets/findify-product-swatches.css
+++ b/assets/findify-product-swatches.css
@@ -37,6 +37,7 @@
 }
 
 .findify-color-tooltip {
+  z-index: 1;
   display: none;
   position: absolute;
   min-width: 50px;

--- a/sections/findify-product-card.liquid
+++ b/sections/findify-product-card.liquid
@@ -26,12 +26,11 @@
       <div class="findify-product-brand">{{ brand }}</div>
     {% endif %}
 
-    {% comment %} {% render 'findify-product-swatches-color', 
-      product_id: id,
+    {% comment %} {% render 'findify-product-swatches-color',
       product_url: product_url,
-      colors: colors,
-      colormap: colormap, 
-      variants: variants, 
+      product: product,
+      colormap: colormap,
+      variants: variants,
     %} {% endcomment %}
     
     <a class="findify-product-link" href={{ product_url }}>

--- a/snippets/findify-product-swatches-color.liquid
+++ b/snippets/findify-product-swatches-color.liquid
@@ -3,8 +3,23 @@
   assign max_colors = 10
 %}
 
+
+{% assign color_keys = "Color,color,Colour,colour,COLOUR,COLOR" | split: ',' %}
+
+{% assign colors = "" %}
+
+{% for key in color_keys %}
+    {% if product.options contains key %}
+         {% for color_option in product.options_by_name[key].values %}
+           {% assign colors = colors | append: color_option | append: "," %}
+         {% endfor %}
+     {% endif %}
+{% endfor %}
+
+{% assign colors_array = colors | split: ',' %}
+
 <div class="findify-color-swatch-wrapper">
-    {% for color in colors  %}
+    {% for color in colors_array  %}
       {% liquid
           assign color_lowercase = color | downcase
           for colormap_item in colormap
@@ -37,12 +52,12 @@
 
         {% assign variant_id = matched_variant | split: "id=" | last | split: "~" | first %}
         {% assign variant_url = product_url | split: "?variant=" | first | append: "?variant=" | append: variant_id %}
-        {% assign variant_image = matched_variant | split: "image_url=" | last | split: "~" | first | append: "&width=940" %}
+        {% assign variant_image = matched_variant | split: "image_url=" | last | split: ";" | first | append: "&width=940" %}
         
         <div 
           class="findify-color-swatch" 
           style="{{styling}}" 
-          onclick="onSwatchClick(event, '{{ product_id }}', '{{ product_url }}', '{{ variant_url }}', '{{ variant_image }}')"
+          onclick="onSwatchClick(event, '{{ product_url }}', '{{ variant_url }}', '{{ variant_image }}')"
         >
           <span class="findify-color-tooltip">
             {{ current_color_name | capitalize }}


### PR DESCRIPTION
- Removed product_id and color fields from findify-product-connector
- Used shopify option color fields for color mapping
- Used .closest method for product card selector